### PR TITLE
Fix cancellation guard cancel detection

### DIFF
--- a/rethread/cancellation_token.hpp
+++ b/rethread/cancellation_token.hpp
@@ -446,7 +446,7 @@ namespace rethread
 		}
 
 		bool is_cancelled() const
-		{ return !_token; }
+		{ return !_token || !*_token; }
 	};
 
 


### PR DESCRIPTION
Small fix for cancellation detection if is_cancelled is  being used to check cancellation of the thread.